### PR TITLE
Travis CI: “async” is a reserved word in Python >= 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
   - "3.5"
-  #- "3.5-dev" # 3.5 development branch
-  #- "nightly" # points to the latest development branch e.g. 3.6-dev
+  - "3.6"
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial  # required for Python >= 3.7
+  allow_failures:
+    - python: "3.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install flake8 -r requirements.txt"
+# stop the build if there are Python syntax errors or undefined names
+before_script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
 # command to run tests
 script: nosetests


### PR DESCRIPTION
Remove Python versions that are end of life and add newer versions.  Run Python 3.7 in __allow_failures__ mode to highlight the changes that will be required to be compatible with Python >= 3.7.

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./hpc_acm/api_client.py:281:62: E999 SyntaxError: invalid syntax
                 response_type=None, auth_settings=None, async=None,
                                                             ^
./hpc_acm/api/default_api.py:131:17: E999 SyntaxError: invalid syntax
            async=params.get('async'),
                ^
2     E999 SyntaxError: invalid syntax
2
```